### PR TITLE
VS Code: prevent shift+enter keybind conflicts

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -24,7 +24,8 @@
     "keybindings": [
       {
         "command": "editor.action.codeAction",
-        "key": "shift+enter",
+        "key": "shift+alt+enter",
+        "when": "editorFocus && editorLangId == 'wdl'",
         "args": {
           "kind": "wdl.run"
         }


### PR DESCRIPTION
Addresses #16.
Tightens up scope of when the editor.action.codeAction command fires from keybinding.
More restrictive keybinding (use alt as well) since shift+enter is very common.
Adds when clauses so only happens when editor has focus and language is wdl.

[My motivation for this was specifically because it was breaking "Find Previous" (which also uses shift+enter) due to the fact that wdl-ide keybindings have precedence because they're an Extension.]